### PR TITLE
Redesign Exec

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pellared/taskflow"
@@ -54,21 +52,8 @@ const toolsDir = "tools"
 func taskClean() taskflow.Task {
 	return taskflow.Task{
 		Name:        "clean",
-		Description: "remove files created during build",
-		Command: func(tf *taskflow.TF) {
-			files, err := filepath.Glob("coverage.*")
-			if err != nil {
-				tf.Fatalf("glob failed: %v", err)
-			}
-			for _, file := range files {
-				err := os.Remove(file)
-				if err != nil {
-					tf.Errorf("failed to remove %s: %v", file, err)
-					continue
-				}
-				tf.Logf("removed %s", file)
-			}
-		},
+		Description: "remove git ignored files",
+		Command:     taskflow.Exec("git", "clean", "-fX"),
 	}
 }
 

--- a/cli.go
+++ b/cli.go
@@ -26,7 +26,10 @@ func (f *Taskflow) Main() {
 		fmt.Fprintf(cli.Output(), "Tasks:\n")
 		w := tabwriter.NewWriter(cli.Output(), 1, 1, 4, ' ', 0)
 		keys := make([]string, 0, len(f.tasks))
-		for k := range f.tasks {
+		for k, task := range f.tasks {
+			if task.Description == "" {
+				continue
+			}
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)

--- a/cli_example_test.go
+++ b/cli_example_test.go
@@ -6,13 +6,9 @@ func Example() {
 	tasks := &taskflow.Taskflow{}
 
 	task1 := tasks.MustRegister(taskflow.Task{
-		Name: "task-1",
-		Command: func(tf *taskflow.TF) {
-			tf.Logf("exec sample")
-			if err := tf.Exec("", nil, "go", "version"); err != nil {
-				tf.Fatalf("go version: %v", err)
-			}
-		},
+		Name:        "task-1",
+		Description: "Print Go version",
+		Command:     taskflow.Exec("go", "version"),
 	})
 
 	task2 := tasks.MustRegister(taskflow.Task{

--- a/exec.go
+++ b/exec.go
@@ -1,23 +1,29 @@
 package taskflow
 
 import (
-	"os"
 	"os/exec"
 	"strings"
 )
 
-// Exec runs the specified command and waits for it to complete.
-// The process stderr and stdout are piped to the Output.
-// Use workdir argument to change the process working directory.
-// Use env argument to provide additional environment variables in the form "key=value".
-func (tf *TF) Exec(workdir string, env []string, name string, args ...string) error {
+// Cmd is like exec.Command, but it assignes tf's context
+// and assigns Stdout and Stderr to tf's output.
+func (tf *TF) Cmd(name string, args ...string) *exec.Cmd {
 	cmdStr := strings.Join(append([]string{name}, args...), " ")
-	tf.Logf("Exec: %s", cmdStr)
+	tf.Logf("Cmd: %s", cmdStr)
 
 	cmd := exec.CommandContext(tf.Context(), name, args...) //nolint:gosec // yes, this runs a subprocess
-	cmd.Dir = workdir
-	cmd.Env = append(os.Environ(), env...)
 	cmd.Stderr = tf.Output()
 	cmd.Stdout = tf.Output()
-	return cmd.Run()
+	return cmd
+}
+
+// Exec returns a command that will run the named program with the given arguments.
+// The command will pass only if the program if the program runs, has no problems
+// copying stdin, stdout, and stderr, and exits with a zero exit status.
+func Exec(name string, args ...string) func(*TF) {
+	return func(tf *TF) {
+		if err := tf.Cmd(name, args...).Run(); err != nil {
+			tf.Fatalf("Cmd %s failed: %v", name, err)
+		}
+	}
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -11,27 +11,20 @@ import (
 
 func TestExec_success(t *testing.T) {
 	sb := &strings.Builder{}
-	var err error
 	r := taskflow.Runner{
 		Output: sb,
 	}
 
-	result := r.Run(func(tf *taskflow.TF) {
-		err = tf.Exec("", nil, "go", "version")
-	})
+	got := r.Run(taskflow.Exec("go", "version"))
 
-	assert.NoError(t, err, "should pass")
-	assert.Contains(t, sb.String(), "go version go1.")
-	assert.True(t, result.Passed(), "task should pass")
+	assert.Contains(t, sb.String(), "go version go")
+	assert.True(t, got.Passed(), "task should pass")
 }
 
 func TestExec_error(t *testing.T) {
-	var err error
 	r := taskflow.Runner{}
 
-	r.Run(func(tf *taskflow.TF) {
-		err = tf.Exec("", nil, "go", "wrong")
-	})
+	got := r.Run(taskflow.Exec("go", "wrong"))
 
-	assert.Error(t, err, "should error, bad go command")
+	assert.True(t, got.Failed(), "task should fail")
 }


### PR DESCRIPTION
## Why

 `Exec` method has an awkward API. Especially due to its first two arguments: `workdir` and `env`. It is also not quite flexible/composable.

## What

- `Exec` - function that returns a command when just execution of the single program is needed.
- `tf.Cmd` - method when we want more flexibility in the command function.
- Additionally, now a task which has no description is not going to be listed when printing "usage".