### PR TITLE
Add parameter conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ The parameters can be set via CLI using `key=val` syntax after CLI flags. For ex
 
 Default values can be assigned via `Params` field in [`type Taskflow`](https://pkg.go.dev/github.com/pellared/taskflow#Taskflow).
 
+[`type Params`](https://pkg.go.dev/github.com/pellared/taskflow#Params) contains convenient conversion methods like [`func (p Params) Int(key string) (int, error)`](https://pkg.go.dev/github.com/pellared/taskflow#Params.Int). The package also includes functions like [`func IsParamNotSet(err error) bool`](https://pkg.go.dev/github.com/pellared/taskflow#IsParamNotSet) to verify the returned errors.
+
 ### Helpers for running programs
 
 Use [`func Exec(name string, args ...string) func(*TF)`](https://pkg.go.dev/github.com/pellared/taskflow#Exec) to create a task's command which only runs a single program.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The parameters can be set via CLI using `key=val` syntax after CLI flags. For ex
 
 Default values can be assigned via `Params` field in [`type Taskflow`](https://pkg.go.dev/github.com/pellared/taskflow#Taskflow).
 
-[`type Params`](https://pkg.go.dev/github.com/pellared/taskflow#Params) contains convenient conversion methods like [`func (p Params) Int(key string) (int, error)`](https://pkg.go.dev/github.com/pellared/taskflow#Params.Int). The package also includes functions like [`func IsParamNotSet(err error) bool`](https://pkg.go.dev/github.com/pellared/taskflow#IsParamNotSet) to verify the returned errors.
+[`type Params`](https://pkg.go.dev/github.com/pellared/taskflow#Params) contains convenient conversion methods like [`func (p Params) Int(key string) (int, error)`](https://pkg.go.dev/github.com/pellared/taskflow#Params.Int).
 
 ### Helpers for running programs
 

--- a/build/build.go
+++ b/build/build.go
@@ -126,7 +126,9 @@ func taskDiff() taskflow.Task {
 		Name:        "diff",
 		Description: "git diff",
 		Command: func(tf *taskflow.TF) {
-			if tf.Params()["ci"] == "" {
+			if isCI, err := tf.Params().Bool("ci"); err != nil {
+				tf.Fatalf(err.Error())
+			} else if !isCI {
 				tf.Skipf("ci param is not set, skipping")
 			}
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,17 @@
+/*
+Package taskflow helps implementing build automation.
+It is intended to be used in concert with the "go run" command,
+to run a program which implements the build pipeline (called taskflow).
+A taskflow consists of a set of registered tasks.
+A task has a name, can have a defined command, which is a function with signature
+	func (*taskflow.TF)
+and can have dependencies (already defined tasks).
+
+When the taskflow is executed for given tasks,
+then the tasks' commands are run in the order defined by their dependencies.
+The task's dependencies are run in a recusrive manner, however each is going to be run at most once.
+
+The taskflow is interupted in case a command fails.
+Within these functions, use the Error, Fail or related methods to signal failure.
+*/
+package taskflow

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,34 @@
+package taskflow_test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pellared/taskflow"
+)
+
+func init() {
+	taskflow.DefaultOutput = ioutil.Discard
+}
+
+func testTF(t *testing.T, flagsAndParams ...string) *taskflow.TF {
+	t.Helper()
+
+	flow := &taskflow.Taskflow{}
+	var got *taskflow.TF
+	flow.MustRegister(taskflow.Task{
+		Name: "task",
+		Command: func(tf *taskflow.TF) {
+			got = tf
+		},
+	})
+
+	args := append(flagsAndParams, "task")
+	exitCode := flow.Run(context.Background(), args...)
+
+	assert.Equal(t, 0, exitCode, "should pass")
+	return got
+}

--- a/params.go
+++ b/params.go
@@ -22,18 +22,6 @@ func (e *ParamError) Error() string {
 // Unwrap unpacks the wrapped error.
 func (e *ParamError) Unwrap() error { return e.Err }
 
-// IsParamNotSet returns a boolean indicating that a parameter is not set.
-func IsParamNotSet(err error) bool {
-	var e *ParamError
-	return errors.As(err, &e) && e.Err == ErrParamNotSet
-}
-
-// IsParamInvalid returns a boolean indicating that a parameter has invalid syntax.
-func IsParamInvalid(err error) bool {
-	var e *ParamError
-	return errors.As(err, &e) && e.Err != ErrParamNotSet
-}
-
 // Params represents Taskflow parameters used within Taskflow.
 // The default values set in the struct are overridden in Run method.
 type Params map[string]string

--- a/params.go
+++ b/params.go
@@ -1,13 +1,9 @@
 package taskflow
 
 import (
-	"errors"
 	"strconv"
 	"time"
 )
-
-// ErrParamNotSet indicates that a parameter is not set.
-var ErrParamNotSet = errors.New("not set")
 
 // ParamError records an error during parameter conversion.
 type ParamError struct {
@@ -27,12 +23,12 @@ func (e *ParamError) Unwrap() error { return e.Err }
 type Params map[string]string
 
 // Int converts the parameter to int using the Go syntax for integer literals.
-// ErrParamNotSet error is returned if the parameter was not set.
+// 0 is returned if the parameter was not set.
 // *strconv.NumError error is returned if the parameter conversion failed.
 func (p Params) Int(key string) (int, error) {
 	v := p[key]
 	if v == "" {
-		return 0, &ParamError{Key: key, Err: ErrParamNotSet}
+		return 0, nil
 	}
 	i, err := strconv.ParseInt(v, 0, strconv.IntSize)
 	if err != nil {
@@ -59,12 +55,12 @@ func (p Params) Bool(key string) (bool, error) {
 }
 
 // Float64 converts the parameter to float64 accepting decimal and hexadecimal floating-point number syntax.
-// ErrParamNotSet error is returned if the parameter was not set.
+// 0 is returned if the parameter was not set.
 // *strconv.NumError error is returned if the parameter conversion failed.
 func (p Params) Float64(key string) (float64, error) {
 	v := p[key]
 	if v == "" {
-		return 0, &ParamError{Key: key, Err: ErrParamNotSet}
+		return 0, nil
 	}
 	f, err := strconv.ParseFloat(v, 64)
 	if err != nil {
@@ -78,12 +74,12 @@ func (p Params) Float64(key string) (float64, error) {
 // decimal numbers, each with optional fraction and a unit suffix,
 // such as "300ms", "-1.5h" or "2h45m".
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-// ErrParamNotSet error is returned if the parameter was not set.
+// 0 is returned if the parameter was not set.
 // An error is also returned if the parameter conversion failed.
 func (p Params) Duration(key string) (time.Duration, error) {
 	v := p[key]
 	if v == "" {
-		return 0, &ParamError{Key: key, Err: ErrParamNotSet}
+		return 0, nil
 	}
 	d, err := time.ParseDuration(v)
 	if err != nil {

--- a/params.go
+++ b/params.go
@@ -6,8 +6,21 @@ import (
 	"time"
 )
 
-// ErrParamNotSet indicates that a parameter is not set.
-var ErrParamNotSet = errors.New("parameter is not set")
+// ParamNotSetError records an error indicating that a parameter is not set.
+type ParamNotSetError struct {
+	Key string
+}
+
+func (err *ParamNotSetError) Error() string {
+	return "parameter " + strconv.Quote(err.Key) + " is not set"
+}
+
+// IsParamNotSet returns a boolean indicating that a parameter is not set.
+// It checks if ErrParamNotSet is present in the error chain.
+func IsParamNotSet(err error) bool {
+	var e *ParamNotSetError
+	return errors.As(err, &e)
+}
 
 // Params represents Taskflow parameters used within Taskflow.
 // The default values set in the struct are overridden in Run method.
@@ -19,7 +32,7 @@ type Params map[string]string
 func (p Params) Int(key string) (int, error) {
 	v := p[key]
 	if v == "" {
-		return 0, ErrParamNotSet
+		return 0, &ParamNotSetError{Key: key}
 	}
 	i, err := strconv.ParseInt(v, 0, strconv.IntSize)
 	return int(i), err
@@ -33,7 +46,7 @@ func (p Params) Int(key string) (int, error) {
 func (p Params) Bool(key string) (bool, error) {
 	v := p[key]
 	if v == "" {
-		return false, ErrParamNotSet
+		return false, &ParamNotSetError{Key: key}
 	}
 	return strconv.ParseBool(v)
 }
@@ -44,7 +57,7 @@ func (p Params) Bool(key string) (bool, error) {
 func (p Params) Float64(key string) (float64, error) {
 	v := p[key]
 	if v == "" {
-		return 0, ErrParamNotSet
+		return 0, &ParamNotSetError{Key: key}
 	}
 	return strconv.ParseFloat(v, 64)
 }
@@ -59,7 +72,7 @@ func (p Params) Float64(key string) (float64, error) {
 func (p Params) Duration(key string) (time.Duration, error) {
 	v := p[key]
 	if v == "" {
-		return 0, ErrParamNotSet
+		return 0, &ParamNotSetError{Key: key}
 	}
 	return time.ParseDuration(v)
 }

--- a/params.go
+++ b/params.go
@@ -1,0 +1,20 @@
+package taskflow
+
+import (
+	"errors"
+	"strconv"
+)
+
+var ErrParamNotSet = errors.New("parameter is not set")
+
+// Params represents Taskflow parameters used within Taskflow.
+// The default values set in the struct are overridden in Run method.
+type Params map[string]string
+
+func (p Params) Int(key string) (int, error) {
+	v := p[key]
+	if v == "" {
+		return 0, ErrParamNotSet
+	}
+	return strconv.Atoi(v)
+}

--- a/params.go
+++ b/params.go
@@ -19,6 +19,9 @@ func (e *ParamError) Error() string {
 	return "taskflow: parameter " + strconv.Quote(e.Key) + ": " + e.Err.Error()
 }
 
+// Unwrap unpacks the wrapped error.
+func (e *ParamError) Unwrap() error { return e.Err }
+
 // IsParamNotSet returns a boolean indicating that a parameter is not set.
 func IsParamNotSet(err error) bool {
 	var e *ParamError

--- a/params.go
+++ b/params.go
@@ -8,7 +8,7 @@ import (
 // ParamError records an error during parameter conversion.
 type ParamError struct {
 	Key string // the parameter's key
-	Err error  // the reason the conversion failed (e.g. ErrParamNotSet, *strconv.NumError, etc.)
+	Err error  // the reason the conversion failure, e.g. *strconv.NumError
 }
 
 func (e *ParamError) Error() string {

--- a/params.go
+++ b/params.go
@@ -3,6 +3,7 @@ package taskflow
 import (
 	"errors"
 	"strconv"
+	"time"
 )
 
 // ErrParamNotSet indicates that a parameter is not set.
@@ -37,7 +38,7 @@ func (p Params) Bool(key string) (bool, error) {
 	return strconv.ParseBool(v)
 }
 
-// Float64 converts the parameter to float accepting decimal and hexadecimal floating-point number syntax.
+// Float64 converts the parameter to float64 accepting decimal and hexadecimal floating-point number syntax.
 // ErrParamNotSet error is returned if the parameter was not set.
 // *strconv.NumError error is returned if the parameter conversion failed.
 func (p Params) Float64(key string) (float64, error) {
@@ -46,4 +47,19 @@ func (p Params) Float64(key string) (float64, error) {
 		return 0, ErrParamNotSet
 	}
 	return strconv.ParseFloat(v, 64)
+}
+
+// Duration converts the parameter to time.Duration using time.ParseDuration.
+// A duration string is a possibly signed sequence of
+// decimal numbers, each with optional fraction and a unit suffix,
+// such as "300ms", "-1.5h" or "2h45m".
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+// ErrParamNotSet error is returned if the parameter was not set.
+// An error is also returned if the parameter conversion failed.
+func (p Params) Duration(key string) (time.Duration, error) {
+	v := p[key]
+	if v == "" {
+		return 0, ErrParamNotSet
+	}
+	return time.ParseDuration(v)
 }

--- a/params.go
+++ b/params.go
@@ -40,13 +40,13 @@ func (p Params) Int(key string) (int, error) {
 
 // Bool converts the parameter to bool.
 // It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
+// False is returned if the parameter was not set.
 // Any other value returns an error.
-// ErrParamNotSet error is returned if the parameter was not set.
 // *strconv.NumError error is returned if the parameter conversion failed.
 func (p Params) Bool(key string) (bool, error) {
 	v := p[key]
 	if v == "" {
-		return false, &ParamNotSetError{Key: key}
+		return false, nil
 	}
 	return strconv.ParseBool(v)
 }

--- a/params.go
+++ b/params.go
@@ -36,3 +36,14 @@ func (p Params) Bool(key string) (bool, error) {
 	}
 	return strconv.ParseBool(v)
 }
+
+// Float64 converts the parameter to float accepting decimal and hexadecimal floating-point number syntax.
+// ErrParamNotSet error is returned if the parameter was not set.
+// *strconv.NumError error is returned if the parameter conversion failed.
+func (p Params) Float64(key string) (float64, error) {
+	v := p[key]
+	if v == "" {
+		return 0, ErrParamNotSet
+	}
+	return strconv.ParseFloat(v, 64)
+}

--- a/params.go
+++ b/params.go
@@ -5,16 +5,21 @@ import (
 	"strconv"
 )
 
+// ErrParamNotSet indicates that a parameter is not set.
 var ErrParamNotSet = errors.New("parameter is not set")
 
 // Params represents Taskflow parameters used within Taskflow.
 // The default values set in the struct are overridden in Run method.
 type Params map[string]string
 
+// Int converts the parameter to int using the same logic as flag package.
+// ErrParamNotSet error is returned if the parameter was not set.
+// *strconv.NumError error is returned if the parameter conversion failed.
 func (p Params) Int(key string) (int, error) {
 	v := p[key]
 	if v == "" {
 		return 0, ErrParamNotSet
 	}
-	return strconv.Atoi(v)
+	i, err := strconv.ParseInt(v, 0, strconv.IntSize)
+	return int(i), err
 }

--- a/params.go
+++ b/params.go
@@ -23,3 +23,16 @@ func (p Params) Int(key string) (int, error) {
 	i, err := strconv.ParseInt(v, 0, strconv.IntSize)
 	return int(i), err
 }
+
+// Bool converts the parameter to bool.
+// It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
+// Any other value returns an error.
+// ErrParamNotSet error is returned if the parameter was not set.
+// *strconv.NumError error is returned if the parameter conversion failed.
+func (p Params) Bool(key string) (bool, error) {
+	v := p[key]
+	if v == "" {
+		return false, ErrParamNotSet
+	}
+	return strconv.ParseBool(v)
+}

--- a/params.go
+++ b/params.go
@@ -12,7 +12,7 @@ var ErrParamNotSet = errors.New("parameter is not set")
 // The default values set in the struct are overridden in Run method.
 type Params map[string]string
 
-// Int converts the parameter to int using the same logic as flag package.
+// Int converts the parameter to int using the Go syntax for integer literals.
 // ErrParamNotSet error is returned if the parameter was not set.
 // *strconv.NumError error is returned if the parameter conversion failed.
 func (p Params) Int(key string) (int, error) {

--- a/params_test.go
+++ b/params_test.go
@@ -67,7 +67,7 @@ func Test_params_Int_missing(t *testing.T) {
 
 	got, err := tf.Params().Int("x")
 
-	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.True(t, taskflow.IsParamNotSet(err), "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -94,7 +94,7 @@ func Test_params_Bool_missing(t *testing.T) {
 
 	got, err := tf.Params().Bool("x")
 
-	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.EqualError(t, err, "parameter \"x\" is not set", "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -121,7 +121,7 @@ func Test_params_Float64_missing(t *testing.T) {
 
 	got, err := tf.Params().Float64("x")
 
-	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.True(t, taskflow.IsParamNotSet(err), "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -148,7 +148,7 @@ func Test_params_Duration_missing(t *testing.T) {
 
 	got, err := tf.Params().Duration("x")
 
-	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.True(t, taskflow.IsParamNotSet(err), "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -78,3 +78,30 @@ func Test_params_Int_invalid(t *testing.T) {
 	assert.Error(t, err, "should tell that it failed to parse the value")
 	assert.Zero(t, got, "should return proper parameter value")
 }
+
+func Test_params_Bool_valid(t *testing.T) {
+	tf := testTF(t, "x=true")
+
+	got, err := tf.Params().Bool("x")
+
+	assert.NoError(t, err, "should parse the value")
+	assert.Equal(t, true, got, "should return proper parameter value")
+}
+
+func Test_params_Bool_missing(t *testing.T) {
+	tf := testTF(t)
+
+	got, err := tf.Params().Bool("x")
+
+	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.Zero(t, got, "should return proper parameter value")
+}
+
+func Test_params_Bool_invalid(t *testing.T) {
+	tf := testTF(t, "x=abc")
+
+	got, err := tf.Params().Bool("x")
+
+	assert.Error(t, err, "should tell that it failed to parse the value")
+	assert.Zero(t, got, "should return proper parameter value")
+}

--- a/params_test.go
+++ b/params_test.go
@@ -3,6 +3,7 @@ package taskflow_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -128,6 +129,33 @@ func Test_params_Float64_invalid(t *testing.T) {
 	tf := testTF(t, "x=abc")
 
 	got, err := tf.Params().Float64("x")
+
+	assert.Error(t, err, "should tell that it failed to parse the value")
+	assert.Zero(t, got, "should return proper parameter value")
+}
+
+func Test_params_Duration_valid(t *testing.T) {
+	tf := testTF(t, "x=1m")
+
+	got, err := tf.Params().Duration("x")
+
+	assert.NoError(t, err, "should parse the value")
+	assert.Equal(t, time.Minute, got, "should return proper parameter value")
+}
+
+func Test_params_Duration_missing(t *testing.T) {
+	tf := testTF(t)
+
+	got, err := tf.Params().Duration("x")
+
+	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.Zero(t, got, "should return proper parameter value")
+}
+
+func Test_params_Duration_invalid(t *testing.T) {
+	tf := testTF(t, "x=abc")
+
+	got, err := tf.Params().Duration("x")
 
 	assert.Error(t, err, "should tell that it failed to parse the value")
 	assert.Zero(t, got, "should return proper parameter value")

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,71 @@
+package taskflow_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pellared/taskflow"
+)
+
+func Test_default_params(t *testing.T) {
+	flow := taskflow.New()
+	flow.Params["x"] = "1"
+	flow.Params["z"] = "0"
+	var got taskflow.Params
+	flow.MustRegister(taskflow.Task{
+		Name: "task",
+		Command: func(tf *taskflow.TF) {
+			got = tf.Params()
+		},
+	})
+
+	exitCode := flow.Run(context.Background(), "y=2", "z=3", "task")
+
+	want := taskflow.Params{
+		"x": "1",
+		"y": "2",
+		"z": "3",
+	}
+	assert.Equal(t, 0, exitCode, "should pass")
+	assert.Equal(t, want, got, "should return proper parameters")
+}
+
+func Test_params(t *testing.T) {
+	tf := testTF(t, "x=1")
+
+	got := tf.Params()
+
+	want := taskflow.Params{
+		"x": "1",
+	}
+	assert.Equal(t, want, got, "should return proper parameters")
+}
+
+func Test_params_Int_valid(t *testing.T) {
+	tf := testTF(t, "x=10")
+
+	got, err := tf.Params().Int("x")
+
+	assert.NoError(t, err, "should parse the value")
+	assert.Equal(t, 10, got, "should return proper parameter value")
+}
+
+func Test_params_Int_missing(t *testing.T) {
+	tf := testTF(t)
+
+	got, err := tf.Params().Int("x")
+
+	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.Zero(t, got, "should return proper parameter value")
+}
+
+func Test_params_Int_invalid(t *testing.T) {
+	tf := testTF(t, "x=abc")
+
+	got, err := tf.Params().Int("x")
+
+	assert.Error(t, err, "should tell that it failed to parse the value")
+	assert.Zero(t, got, "should return proper parameter value")
+}

--- a/params_test.go
+++ b/params_test.go
@@ -3,6 +3,7 @@ package taskflow_test
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -68,7 +69,7 @@ func Test_params_Int_missing(t *testing.T) {
 
 	got, err := tf.Params().Int("x")
 
-	assert.True(t, errors.Is(err, taskflow.ErrParamNotSet), "should tell that parameter was not set")
+	assert.NoError(t, err, "should not return any error")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -77,7 +78,7 @@ func Test_params_Int_invalid(t *testing.T) {
 
 	got, err := tf.Params().Int("x")
 
-	assert.False(t, errors.Is(err, taskflow.ErrParamNotSet), "should tell that it failed to parse the value")
+	assert.Error(t, err, "should tell that it failed to parse the value")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -104,7 +105,7 @@ func Test_params_Bool_invalid(t *testing.T) {
 
 	got, err := tf.Params().Bool("x")
 
-	assert.Error(t, err, "should tell that it failed to parse the value")
+	assert.EqualError(t, err, "taskflow: parameter \"x\": strconv.ParseBool: parsing \"abc\": invalid syntax", "should tell that it failed to parse the value")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -122,7 +123,7 @@ func Test_params_Float64_missing(t *testing.T) {
 
 	got, err := tf.Params().Float64("x")
 
-	assert.EqualError(t, err, "taskflow: parameter \"x\": not set", "should tell that parameter was not set")
+	assert.NoError(t, err, "should not return any error")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -131,7 +132,8 @@ func Test_params_Float64_invalid(t *testing.T) {
 
 	got, err := tf.Params().Float64("x")
 
-	assert.Error(t, err, "should tell that it failed to parse the value")
+	var paramErr *strconv.NumError
+	assert.True(t, errors.As(err, &paramErr), "should tell that it failed to parse the value")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -149,7 +151,7 @@ func Test_params_Duration_missing(t *testing.T) {
 
 	got, err := tf.Params().Duration("x")
 
-	assert.True(t, errors.Is(err, taskflow.ErrParamNotSet), "should tell that parameter was not set")
+	assert.NoError(t, err, "should not return any error")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -105,3 +105,30 @@ func Test_params_Bool_invalid(t *testing.T) {
 	assert.Error(t, err, "should tell that it failed to parse the value")
 	assert.Zero(t, got, "should return proper parameter value")
 }
+
+func Test_params_Float64_valid(t *testing.T) {
+	tf := testTF(t, "x=1.2")
+
+	got, err := tf.Params().Float64("x")
+
+	assert.NoError(t, err, "should parse the value")
+	assert.Equal(t, 1.2, got, "should return proper parameter value")
+}
+
+func Test_params_Float64_missing(t *testing.T) {
+	tf := testTF(t)
+
+	got, err := tf.Params().Float64("x")
+
+	assert.Equal(t, taskflow.ErrParamNotSet, err, "should tell that parameter was not set")
+	assert.Zero(t, got, "should return proper parameter value")
+}
+
+func Test_params_Float64_invalid(t *testing.T) {
+	tf := testTF(t, "x=abc")
+
+	got, err := tf.Params().Float64("x")
+
+	assert.Error(t, err, "should tell that it failed to parse the value")
+	assert.Zero(t, got, "should return proper parameter value")
+}

--- a/params_test.go
+++ b/params_test.go
@@ -2,6 +2,7 @@ package taskflow_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -67,7 +68,7 @@ func Test_params_Int_missing(t *testing.T) {
 
 	got, err := tf.Params().Int("x")
 
-	assert.True(t, taskflow.IsParamNotSet(err), "should tell that parameter was not set")
+	assert.True(t, errors.Is(err, taskflow.ErrParamNotSet), "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -76,7 +77,7 @@ func Test_params_Int_invalid(t *testing.T) {
 
 	got, err := tf.Params().Int("x")
 
-	assert.True(t, taskflow.IsParamInvalid(err), "should tell that parameter was not set")
+	assert.False(t, errors.Is(err, taskflow.ErrParamNotSet), "should tell that it failed to parse the value")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -148,7 +149,7 @@ func Test_params_Duration_missing(t *testing.T) {
 
 	got, err := tf.Params().Duration("x")
 
-	assert.True(t, taskflow.IsParamNotSet(err), "should tell that parameter was not set")
+	assert.True(t, errors.Is(err, taskflow.ErrParamNotSet), "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -94,8 +94,8 @@ func Test_params_Bool_missing(t *testing.T) {
 
 	got, err := tf.Params().Bool("x")
 
-	assert.EqualError(t, err, "parameter \"x\" is not set", "should tell that parameter was not set")
-	assert.Zero(t, got, "should return proper parameter value")
+	assert.NoError(t, err, "should not return any error")
+	assert.Equal(t, false, got, "should return false as the default value")
 }
 
 func Test_params_Bool_invalid(t *testing.T) {
@@ -121,7 +121,7 @@ func Test_params_Float64_missing(t *testing.T) {
 
 	got, err := tf.Params().Float64("x")
 
-	assert.True(t, taskflow.IsParamNotSet(err), "should tell that parameter was not set")
+	assert.EqualError(t, err, "parameter \"x\" is not set", "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -76,7 +76,7 @@ func Test_params_Int_invalid(t *testing.T) {
 
 	got, err := tf.Params().Int("x")
 
-	assert.Error(t, err, "should tell that it failed to parse the value")
+	assert.True(t, taskflow.IsParamInvalid(err), "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 
@@ -121,7 +121,7 @@ func Test_params_Float64_missing(t *testing.T) {
 
 	got, err := tf.Params().Float64("x")
 
-	assert.EqualError(t, err, "parameter \"x\" is not set", "should tell that parameter was not set")
+	assert.EqualError(t, err, "taskflow: parameter \"x\": not set", "should tell that parameter was not set")
 	assert.Zero(t, got, "should return proper parameter value")
 }
 

--- a/params_test.go
+++ b/params_test.go
@@ -43,13 +43,22 @@ func Test_params(t *testing.T) {
 	assert.Equal(t, want, got, "should return proper parameters")
 }
 
-func Test_params_Int_valid(t *testing.T) {
+func Test_params_Int_valid_dec(t *testing.T) {
 	tf := testTF(t, "x=10")
 
 	got, err := tf.Params().Int("x")
 
 	assert.NoError(t, err, "should parse the value")
 	assert.Equal(t, 10, got, "should return proper parameter value")
+}
+
+func Test_params_Int_valid_binary(t *testing.T) {
+	tf := testTF(t, "x=0b10")
+
+	got, err := tf.Params().Int("x")
+
+	assert.NoError(t, err, "should parse the value")
+	assert.Equal(t, 2, got, "should return proper parameter value")
 }
 
 func Test_params_Int_missing(t *testing.T) {

--- a/taskflow.go
+++ b/taskflow.go
@@ -1,19 +1,3 @@
-/*
-Package taskflow helps implementing build automation.
-It is intended to be used in concert with the "go run" command,
-to run a program which implements the build pipeline (called taskflow).
-A taskflow consists of a set of registered tasks.
-A task has a name, can have a defined command, which is a function with signature
-	func (*taskflow.TF)
-and can have dependencies (already defined tasks).
-
-When the taskflow is executed for given tasks,
-then the tasks' commands are run in the order defined by their dependencies.
-The task's dependencies are run in a recusrive manner, however each is going to be run at most once.
-
-The taskflow is interupted in case a command fails.
-Within these functions, use the Error, Fail or related methods to signal failure.
-*/
 package taskflow
 
 import (
@@ -53,10 +37,6 @@ type Taskflow struct {
 type RegisteredTask struct {
 	name string
 }
-
-// Params represents Taskflow parameters used within Taskflow.
-// The default values set in the struct are overridden in Run method.
-type Params map[string]string
 
 // New return a valid instance of Taskflow with DefaultOutput and initized Params.
 func New() *Taskflow {

--- a/taskflow_test.go
+++ b/taskflow_test.go
@@ -2,7 +2,6 @@ package taskflow_test
 
 import (
 	"context"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,10 +9,6 @@ import (
 
 	"github.com/pellared/taskflow"
 )
-
-func init() {
-	taskflow.DefaultOutput = ioutil.Discard
-}
 
 func Test_Register(t *testing.T) {
 	testCases := []struct {
@@ -245,39 +240,6 @@ func Test_empty_command(t *testing.T) {
 	assert.Equal(t, 0, exitCode, "should pass")
 }
 
-func Test_verbose(t *testing.T) {
-	flow := &taskflow.Taskflow{}
-	var got bool
-	flow.MustRegister(taskflow.Task{
-		Name: "task",
-		Command: func(tf *taskflow.TF) {
-			got = tf.Verbose()
-		},
-	})
-
-	exitCode := flow.Run(context.Background(), "-v", "task")
-
-	assert.Equal(t, 0, exitCode, "should pass")
-	assert.True(t, got, "should return proper Verbose value")
-}
-
-func Test_name(t *testing.T) {
-	flow := &taskflow.Taskflow{}
-	taskName := "task"
-	var got string
-	flow.MustRegister(taskflow.Task{
-		Name: taskName,
-		Command: func(tf *taskflow.TF) {
-			got = tf.Name()
-		},
-	})
-
-	exitCode := flow.Run(context.Background(), "-v", "task")
-
-	assert.Equal(t, 0, exitCode, "should pass")
-	assert.Equal(t, taskName, got, "should return proper Name value")
-}
-
 func Test_invalid_args(t *testing.T) {
 	flow := &taskflow.Taskflow{}
 	flow.MustRegister(taskflow.Task{
@@ -317,44 +279,27 @@ func Test_invalid_args(t *testing.T) {
 	}
 }
 
-func Test_params(t *testing.T) {
+func Test_name(t *testing.T) {
 	flow := &taskflow.Taskflow{}
-	var got taskflow.Params
+	taskName := "my-named-task"
+	var got string
 	flow.MustRegister(taskflow.Task{
-		Name: "task",
+		Name: taskName,
 		Command: func(tf *taskflow.TF) {
-			got = tf.Params()
+			got = tf.Name()
 		},
 	})
 
-	exitCode := flow.Run(context.Background(), "x=1", "task")
+	exitCode := flow.Run(context.Background(), "-v", taskName)
 
-	want := taskflow.Params{
-		"x": "1",
-	}
 	assert.Equal(t, 0, exitCode, "should pass")
-	assert.Equal(t, want, got, "should return proper parameters")
+	assert.Equal(t, taskName, got, "should return proper Name value")
 }
 
-func Test_default_params(t *testing.T) {
-	flow := taskflow.New()
-	flow.Params["x"] = "1"
-	flow.Params["z"] = "0"
-	var got taskflow.Params
-	flow.MustRegister(taskflow.Task{
-		Name: "task",
-		Command: func(tf *taskflow.TF) {
-			got = tf.Params()
-		},
-	})
+func Test_verbose(t *testing.T) {
+	tf := testTF(t, "-v")
 
-	exitCode := flow.Run(context.Background(), "y=2", "z=3", "task")
+	got := tf.Verbose()
 
-	want := taskflow.Params{
-		"x": "1",
-		"y": "2",
-		"z": "3",
-	}
-	assert.Equal(t, 0, exitCode, "should pass")
-	assert.Equal(t, want, got, "should return proper parameters")
+	assert.True(t, got, "should return proper Verbose value")
 }


### PR DESCRIPTION
## Why

The most popular build pipeline parameters types are integers, booleans, floats and time intervals (duration).

## What

Add parameter conversion convenient methods together with other necessary types and functions.

## What is next

- Convert to custom types implementing https://golang.org/pkg/encoding/#TextUnmarshaler
- Convert to `time.Date`